### PR TITLE
fixing relativePath for spring-shell-dependencies

### DIFF
--- a/spring-shell-dependencies/pom.xml
+++ b/spring-shell-dependencies/pom.xml
@@ -9,7 +9,7 @@
 		<artifactId>spring-shell-parent</artifactId>
 		<groupId>org.springframework.shell</groupId>
 		<version>3.0.0.BUILD-SNAPSHOT</version>
-		<relativePath />
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<dependencyManagement>


### PR DESCRIPTION
Updated relativePath so that it will build correctly
https://github.com/spring-projects/spring-shell/issues/322